### PR TITLE
Compute new credentials annotations for parameters

### DIFF
--- a/demo/APIC-709/APIC-709.raml
+++ b/demo/APIC-709/APIC-709.raml
@@ -1,0 +1,23 @@
+#%RAML 1.0
+title: APIC-709
+
+annotationTypes:
+  credentialsId: boolean
+  credentialsSecret: boolean
+
+securitySchemes:
+  Pepe:
+    type: x-MyScheme
+    describedBy:
+      headers:
+        strangeId:
+          type: string
+          (credentialsId): true
+        strangeSecret:
+          type: string
+          (credentialsSecret): true
+
+/test:
+  securedBy:
+    - Pepe
+  get:

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -6,5 +6,6 @@
   "annotated-oauth2/annotated-oauth2.raml": "RAML 1.0",
   "APIC-298/APIC-298.json": ["OAS 2.0", "application/json"],
   "APIC-289/APIC-289.yaml": ["OAS 2.0", "application/yaml"],
-  "no-auto-encoding/no-auto-encoding.raml": "RAML 1.0"
+  "no-auto-encoding/no-auto-encoding.raml": "RAML 1.0",
+  "APIC-709/APIC-709.raml": "RAML 1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-forms",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-forms",
   "description": "A library containing helper classes to compute API data from the AMF web API model.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiViewModel.js
+++ b/src/ApiViewModel.js
@@ -371,7 +371,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       const node = model[id];
       const extensionNameKey = this._getAmfKey(this.ns.aml.vocabularies.core.extensionName);
       if (this._getValue(node, extensionNameKey) === annotationName) {
-        return this._getValue(node, this.ns.aml.vocabularies.data.value) === true;
+        return this._getValue(node, this.ns.aml.vocabularies.data.value) === 'true';
       }
     }
     return undefined

--- a/test/ApiViewModel-AMF.test.js
+++ b/test/ApiViewModel-AMF.test.js
@@ -833,6 +833,35 @@ describe('ApiViewModel', () => {
           assert.isFalse(item.schema.isNillable);
         });
       });
+
+      describe('APIC-709', () => {
+        let amf;
+
+        before(async () => {
+          amf = await AmfLoader.load(/** @type boolean */ (compact), 'APIC-709');
+        });
+
+        let model;
+        let element = /** @type ApiViewModel */ (null);
+        let headers;
+
+        beforeEach(() => {
+          element = new ApiViewModel({ amf });
+          model = AmfLoader.lookupSecurityScheme(amf, '/test', 'get', 'Pepe');
+          const hKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.header);
+          headers = element._ensureArray(model[hKey]);
+        });
+
+        it('should compute isCredentialsId field for first item', () => {
+          const result = element.computeViewModel(headers);
+          assert.isTrue(result[0].schema.isCredentialsIdField);
+        });
+
+        it('should compute isCredentialsSecret field for second item', () => {
+          const result = element.computeViewModel(headers);
+          assert.isTrue(result[1].schema.isCredentialsSecretField);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Adding computations for the feature implementation of being able to populate credentials fields via events.
In the `schema` of the UI parameter model, compute `isCredentialsIdField` and `isCredentialsSecretField`, compute from annotation in parameter, add only if true.